### PR TITLE
getProfile()의 nullable 처리

### DIFF
--- a/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.java
+++ b/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.java
@@ -156,9 +156,17 @@ public class RNKakaoLoginsModule extends ReactContextBaseJavaModule {
 
             Account kakaoUser = user.getKakaoAccount();
             map.putString("email", String.valueOf(kakaoUser.getEmail()));
-            map.putString("nickname", String.valueOf(kakaoUser.getProfile().getNickname()));
-            map.putString("profileImageUrl", String.valueOf(kakaoUser.getProfile().getProfileImageUrl()));
-            map.putString("thumbnailImageUrl", String.valueOf(kakaoUser.getProfile().getThumbnailImageUrl()));
+            
+            if (kakaoUser.getProfile() == null) {
+                map.putString("nickname", "null");
+                map.putString("profileImageUrl", "null");
+                map.putString("thumbnailImageUrl", "null");
+            } else {
+                map.putString("nickname", String.valueOf(kakaoUser.getProfile().getNickname()));
+                map.putString("profileImageUrl", String.valueOf(kakaoUser.getProfile().getProfileImageUrl()));
+                map.putString("thumbnailImageUrl", String.valueOf(kakaoUser.getProfile().getThumbnailImageUrl()));
+            }
+            
             map.putString("phoneNumber", String.valueOf(kakaoUser.getPhoneNumber()));
             map.putString("ageRange", String.valueOf(user.getKakaoAccount().getAgeRange()));
             map.putString("birthday", String.valueOf(kakaoUser.getBirthday()));


### PR DESCRIPTION
v3로 업그레이드한 이후 getNickname()을 가져올때 null로 인해 에러가 발생하고 앱이 계속 꺼지는 증상이 있었습니다.

그래서 getProfile()이 null 일 경우와 아닐경우로 나눠서 처리를 해주었더니 정상적으로 작동하고있습니다.